### PR TITLE
Allow setting UI and API ports via env var

### DIFF
--- a/actix-api/src/main.rs
+++ b/actix-api/src/main.rs
@@ -25,10 +25,10 @@ const OAUTH_TOKEN_URL: &str = std::env!("OAUTH_TOKEN_URL");
 const OAUTH_SECRET: &str = std::env!("OAUTH_CLIENT_SECRET");
 const OAUTH_REDIRECT_URL: &str = std::env!("OAUTH_REDIRECT_URL");
 const SCOPE: &str = "email%20profile%20openid";
-const AFTER_LOGIN_URL: &str = "http://localhost/";
 const ACTIX_PORT: &str = std::env!("ACTIX_PORT");
 const UI_PORT: &str = std::env!("TRUNK_SERVE_PORT");
 const UI_HOST: &str = std::env!("TRUNK_SERVE_HOST");
+const AFTER_LOGIN_URL: &'static str = concat!("http://localhost:", std::env!("TRUNK_SERVE_PORT"));
 
 pub mod auth;
 pub mod db;

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,32 +8,32 @@ services:
         target: /app
     build: 
       dockerfile: ../docker/Dockerfile.yew
-    command: bash -c "cd app/yew-ui && trunk serve --address 0.0.0.0"
+    command: bash -c "cd app/yew-ui && trunk serve --address 0.0.0.0 --port ${TRUNK_SERVE_PORT:-80}"
     environment:
-      - ACTIX_PORT=8080 
-      - TRUNK_SERVE_PORT=80
+      - ACTIX_PORT=${ACTIX_PORT:-8080}
+      - TRUNK_SERVE_PORT=${TRUNK_SERVE_PORT:-80}
       - ENABLE_OAUTH=true
-      - LOGIN_URL=http://localhost:8080/login
+      - LOGIN_URL=http://localhost:${ACTIX_PORT:-8080}/login
     ports:
-      - "80:80"  
+      - "${TRUNK_SERVE_PORT:-80}:${TRUNK_SERVE_PORT:-80}"
 
   actix-api:
     build: 
       dockerfile: ../docker/Dockerfile.actix
     command: bash -c "cd app/actix-api && cargo watch -x \"run\""
     environment:
-      - ACTIX_PORT=8080
-      - TRUNK_SERVE_PORT=80
+      - ACTIX_PORT=${ACTIX_PORT:-8080}
+      - TRUNK_SERVE_PORT=${TRUNK_SERVE_PORT:-80}
       - TRUNK_SERVE_HOST=localhost
       - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
       - OAUTH_AUTH_URL=${OAUTH_AUTH_URL}
       - OAUTH_TOKEN_URL=${OAUTH_TOKEN_URL}
       - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
-      - OAUTH_REDIRECT_URL=http://localhost:8080/login/callback
+      - OAUTH_REDIRECT_URL=http://localhost:${ACTIX_PORT:-8080}/login/callback
       - RUST_LOG=info
       - PG_URL=postgres://postgres:docker@postgres:5432/actix-api-db?sslmode=disable
     ports:
-      - "8080:8080"
+      - "${ACTIX_PORT:-8080}:${ACTIX_PORT:-8080}"
     volumes:
       - type: bind
         source: ../


### PR DESCRIPTION
Make sure the UI and API respect any values set for `ACTIX_PORT` and `TRUNK_SERVE_PORT`. Have these values default to ACTIX_PORT=8080 and TRUNK_SERVE_PORT=80 in the absence of any .env file.