### PR TITLE
Docker improvement: create volume for caching ui and actix binaries.

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
       - type: bind
         source: ../
         target: /app
+      - /app/yew-ui/target
     build: 
       dockerfile: ../docker/Dockerfile.yew
     command: bash -c "cd app/yew-ui && trunk serve --address 0.0.0.0 --port ${TRUNK_SERVE_PORT:-80}"
@@ -38,6 +39,7 @@ services:
       - type: bind
         source: ../
         target: /app
+      - /app/actix-api/target
     depends_on:
       - postgres
 


### PR DESCRIPTION
Right now we bind EVERYTHING under `../` to `/app` this is expensive, especially on mac os, which leads to longer compile times.

This fixes that by creating volumes for both the UI and actix-web to keep its cached compiled binaries.